### PR TITLE
fix: remove Quay.io references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,3 @@ docker run ghcr.io/cniweb/cpuminer-multi:latest
 ```bash
 docker run docker.io/cniweb/cpuminer-multi:latest
 ```
-
-## Usage from Quay.io
-
-```bash
-docker run quay.io/cniweb/cpuminer-multi:latest
-```


### PR DESCRIPTION
Quay.io-Repos sind gelöscht, Images können nicht mehr dorthin gepusht werden. Entfernt den "Usage from Quay.io"-Abschnitt aus der README.