### PR TITLE
chore: add prompts, copilot-instructions, dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Git
+.git
+.gitignore
+.github
+
+# Documentation
+README.md
+CHANGELOG.md
+AGENTS.md
+LICENSE
+
+# Build artifacts
+**/*.tar.gz
+**/*.zip
+
+# Temporary files
+*.tmp
+*.temp
+**/.DS_Store
+
+# IDE files
+.vscode
+.idea
+*.swp
+*.swo
+
+# Logs
+*.log
+**/*.log
+
+# Whitesource config
+.whitesource
+
+# Compose files (not needed in image build context)
+compose.yaml
+compose.*.yaml
+
+# Environment examples
+.env.example

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Project Guidelines
+
+## Code Style
+- Keep Dockerfiles and shell scripts minimal and explicit.
+- Preserve existing shell style (`set -eu`, POSIX-friendly syntax) in `*.sh` files.
+- Prefer environment-driven runtime configuration over hardcoded values.
+
+## Architecture
+- This repository builds cpuminer-multi from source (git clone from `tpruvot/cpuminer-multi`) inside a Debian-based container image.
+- Runtime:
+  - Default image behavior: non-root `cpuminer` user, `CMD` runs `cpuminer --config=config.json`.
+  - There is no entrypoint script; the binary runs directly via `CMD` or a user-supplied command.
+- Key files:
+  - `Dockerfile`: image definition — installs build deps, compiles from source, installs binary, removes build deps.
+  - `build.sh`: build, tag, and push workflow.
+  - `config.json`: default mining configuration.
+
+## Build and Test
+- Standard build: `docker build . -t cniweb/cpuminer-multi:test`
+- Build helper: `./build.sh build-only`
+- Validate image: `docker run --rm cniweb/cpuminer-multi:test cpuminer --version`
+- Validate miner functionality: `docker run --rm cniweb/cpuminer-multi:test cpuminer --cputest`
+- Security checks: `./security-check.sh`
+
+## Conventions
+- Keep cpuminer-multi version synchronized across all four files: `Dockerfile`, `build.sh`, `README.md`, and `CHANGELOG.md`. The release workflow handles all four automatically, promoting `CHANGELOG.md`'s `## [Unreleased]` section to a dated version heading; it fails if that section is missing, so add one before triggering a release.
+- Use port `8080` consistently.
+- The image runs as a non-root `cpuminer` user by default for security.
+- For releases, prefer workflow `.github/workflows/release-from-version.yml`.
+- Do not duplicate long docs in instructions; reference:
+  - `README.md` for runtime usage.
+  - `AGENTS.md` for repo conventions, CI behavior, and known gotchas.

--- a/.github/prompts/create-release.prompt.md
+++ b/.github/prompts/create-release.prompt.md
@@ -1,0 +1,37 @@
+---
+mode: "agent"
+description: "Create a new cpuminer-multi release: check for new upstream versions, bump versions, update CHANGELOG.md, then tag and publish a GitHub release."
+---
+
+Create a release for this repository.
+
+## Workflow
+
+1. **Version input.** If no version is provided in the request, ask for it (format `1.3.7` or `v1.3.7`).
+2. **Normalize** to `VERSION` (without `v`) and `TAG` (`v${VERSION}`).
+3. **Fetch upstream cpuminer-multi release notes** from the upstream GitHub releases using `gh release list --repo tpruvot/cpuminer-multi --limit 5`. For the specific version, run `gh release view v${VERSION} --repo tpruvot/cpuminer-multi --json body -q .body`. Extract the changelog items (bug fixes, features, improvements) — ignore SHA256 checksums and GPG signatures.
+4. **Update `CHANGELOG.md`**: add a new section at the top (below the header) with:
+   - `## [${VERSION}] - ${YYYY-MM-DD}` (today's date)
+   - `### Upstream cpuminer-multi changes` — list items from step 3
+   - `### Packaging changes` — list any packaging changes made in this release (if any)
+5. **Update version references** in these files:
+   - `Dockerfile` → `ARG VERSION_TAG=${VERSION}`
+   - `build.sh` → `version="${VERSION}"`
+   - `README.md` → version strings under "Version Notes"
+6. **Validate** with:
+   - `docker build . -t cniweb/cpuminer-multi:test`
+   - `docker run --rm cniweb/cpuminer-multi:test cpuminer --version`
+7. **Commit** using message: `chore(release): ${TAG}`
+8. **Create and push** Git tag `${TAG}`.
+9. **Create a GitHub release** with title/body based on the latest previous release text, replacing old tag/version with the new one. Include a summary of upstream changes in the release body.
+10. **Report** exactly which files changed and final tag/release URL.
+
+Prefer using the workflow `Create Release From Version` (`.github/workflows/release-from-version.yml`) when possible. The workflow handles steps 5, 7, 8, and 9 automatically but does **not** update `CHANGELOG.md` — that must be done manually or by the agent before running the workflow.
+
+## Checking for new upstream versions
+
+When asked to check for a new cpuminer-multi version:
+
+1. Run `gh release list --repo tpruvot/cpuminer-multi --limit 5` to find the latest release.
+2. Compare with the current version in `Dockerfile` (`ARG VERSION_TAG=...`).
+3. If a newer version exists, report it and ask whether to proceed with the release workflow above.


### PR DESCRIPTION
- `.github/prompts/create-release.prompt.md` – Agent Prompt für Releases
- `.github/copilot-instructions.md` – Anleitung für GitHub Copilot
- `.dockerignore` – Build-Kontext-Optimierung