### PR TITLE
fix: use ARG VERSION_TAG in git checkout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:trixie-slim
 
 # Set non-root user early
-ARG VERSION_TAG=1.3.7
+ARG VERSION_TAG=v1.3.7
 ARG CPUMINER_USER=cpuminer
 ARG CPUMINER_UID=1000
 ARG CPUMINER_GID=1000
@@ -38,6 +38,7 @@ RUN set -x \
     # Compile from source code.
     && git clone --recursive https://github.com/tpruvot/cpuminer-multi.git -b linux /tmp/cpuminer \
     && cd /tmp/cpuminer \
+    && git checkout "$VERSION_TAG" \
     && ./autogen.sh \
     && extracflags="$extracflags -Ofast -flto -fuse-linker-plugin -ftree-loop-if-convert-stores" \
     && CFLAGS="-O2 $extracflags -DUSE_ASM -pg" ./configure --with-crypto --with-curl \


### PR DESCRIPTION
`ARG VERSION_TAG` war deklariert aber nie verwendet – `build.sh` übergab `--build-arg VERSION_TAG=v$version` ins Leere.

- ARG-Default auf `v1.3.7` korrigiert (Upstream-Tags haben `v`-Prefix)
- `git checkout "$VERSION_TAG"` nach dem Clone eingefügt