### PR TITLE
chore: remove orphaned workflow, optimize dockerignore, add build badge

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,6 +28,10 @@ LICENSE
 *.log
 **/*.log
 
+# Build and test scripts
+build.sh
+security-check.sh
+
 # Whitesource config
 .whitesource
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,2 +1,0 @@
-# This workflow has been replaced by docker-build.yml
-# See .github/workflows/docker-build.yml for the current CI pipeline

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a multi-threaded CPU miner, fork of pooler's cpuminer.
 
-[![Snyk Container](https://github.com/cniweb/cpuminer-multi-docker/actions/workflows/snyk-container-analysis.yml/badge.svg)](https://github.com/cniweb/cpuminer-multi-docker/actions/workflows/snyk-container-analysis.yml)
+[![Build & Push Docker Image](https://github.com/cniweb/cpuminer-multi-docker/actions/workflows/docker-build.yml/badge.svg)](https://github.com/cniweb/cpuminer-multi-docker/actions/workflows/docker-build.yml) [![Snyk Container](https://github.com/cniweb/cpuminer-multi-docker/actions/workflows/snyk-container-analysis.yml/badge.svg)](https://github.com/cniweb/cpuminer-multi-docker/actions/workflows/snyk-container-analysis.yml)
 
 ## Usage from ghcr.io
 


### PR DESCRIPTION
- Gelöscht: `.github/workflows/docker-image.yml` (deprecated, ersetzt durch docker-build.yml)
- `.dockerignore`: build.sh + security-check.sh exkludiert
- README: Badge für docker-build.yml hinzugefügt