### PR TITLE
fix: add set -eu to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eu
+
 # Build script for cpuminer-multi Docker image
 # Define image name, version and registries
 image="cpuminer-multi"


### PR DESCRIPTION
`set -eu` für Fail-Fast-Verhalten – bricht bei fehlgeschlagenen Commands ab statt still weiterzumachen.